### PR TITLE
Fixes ServiceParser not implementing the 'share' option correctly.

### DIFF
--- a/src/ServiceParser.php
+++ b/src/ServiceParser.php
@@ -82,7 +82,7 @@ class ServiceParser
         $raw = array_merge($services, $controllers);
 
         foreach ($raw as $name => $values) {
-            if (isset($values['shared']) && $values['shared'] === true) {
+            if (isset($values['share']) && $values['share'] === true) {
                 // Shared service; ie: saves a single copy of the object passed in
                 $app[$name] = $app->share(function() use ($values) {
                     $class = new \ReflectionClass($values['class']);


### PR DESCRIPTION
The `ServiceParser` sometimes checks for 'shared' set to true, rather than the documented 'share'. This option determines if the service is registered with the Pimple `$app->share()` method, which causes the service instance to be re-used across service-locator requests.

The option is documented as 'share': https://studionone.github.io/flint/services.html#syntax-for-app-services-php

This is particularly bad as:
- we check for 'shared' in `ServiceParser::parse()`, and only use `$app->share()` if 'shared' is set to true. This means services with 'share' set to true aren't registered that way, against documentation.
- `ServiceParser::loadControllers()` still checks and sets 'share', but relies on `ServiceParser::parse()` to apply the behaviour. This means that none of our controller services are being registered as shared, despite this being the desired behaviour.
